### PR TITLE
Update app/test/scripts/influxdb.conf

### DIFF
--- a/app/test/scripts/influxdb.conf
+++ b/app/test/scripts/influxdb.conf
@@ -8,7 +8,8 @@ bind-address = "127.0.0.1:8088"
 
 [data]
   dir = "./data"
-  index-version = "inmem"
+  #index-version = "inmem"
+  index-version = "tsi1"
   wal-dir = "./wal"
   wal-fsync-delay = "0s"
   query-log-enabled = true


### PR DESCRIPTION
changed default storage to be tsi so will deal with very large datasets without exhausting memory.